### PR TITLE
Move `grip-up` event to after reparent to allow for custom rotations on release

### DIFF
--- a/src/components/holdable/holdable.js
+++ b/src/components/holdable/holdable.js
@@ -392,11 +392,6 @@ AFRAME.registerComponent("holdable", {
     },
     onGripUp: function (evt) {
         if (!this.isHeld || !this.holdingHand) return;
-        // Emit grip-up event with details
-        this.el.emit("grip-up", {
-            hand: this.holdingHand,
-            entity: this.el,
-        });
         this.el.object3D.updateMatrixWorld(true);
         // Reparent back to the original parent.
         this.originalParent.object3D.attach(this.el.object3D);
@@ -466,6 +461,11 @@ AFRAME.registerComponent("holdable", {
         }
         // Modifiers - Clear saved component states
         this.savedComponentStates = {};
+        // Emit grip-up event with details
+        this.el.emit("grip-up", {
+            hand: this.holdingHand,
+            entity: this.el,
+        });
         // Simulate pulling the raycaster away by temporarily setting the raycaster's far value to 0, then restoring it. This lets the user grab the object again without moving the controller away first.
         const handEls = document.querySelectorAll("[meta-touch-controls], [oculus-touch-controls], [hand-controls]");
         if (handEls) {

--- a/src/components/holdable/holdable.js
+++ b/src/components/holdable/holdable.js
@@ -462,6 +462,7 @@ AFRAME.registerComponent("holdable", {
         // Modifiers - Clear saved component states
         this.savedComponentStates = {};
         // Emit grip-up event with details
+        // Note: Located here so that entity is reparented back and modifiers are restored if applicable.
         this.el.emit("grip-up", {
             hand: this.holdingHand,
             entity: this.el,


### PR DESCRIPTION
This pull request makes a minor adjustment to the timing of the `grip-up` event emission in the `holdable` component. The event is now emitted after clearing saved component states and before simulating raycaster reset, rather than immediately upon grip release.

https://trello.com/c/7EJyrZYf