### PR TITLE
Feature/holdable/96 add debug option

### DIFF
--- a/src/components/holdable/holdable.js
+++ b/src/components/holdable/holdable.js
@@ -342,9 +342,8 @@ AFRAME.registerComponent("holdable", {
                 // Fall back to the computed position (where it was actually grabbed).
                 customGrabPos = pos;
                 useCustomPos = false;
-                // Debug - pasteable attribute that reproduces this grab (order: XYZ, mirrors left-hand like apply path)
+                // Debug - pasteable attribute to reproduce grab position/rotation
                 if (this.data.debug) {
-                    // If hand is left, output "Use right hand to get position and rotation values"
                     if (handType === "left") {
                         console.log("Use right hand to get position and rotation values. The left hand automatically mirrors the right.");
                     } else {


### PR DESCRIPTION
This pull request adds a new debugging feature to the `holdable` component in `src/components/holdable/holdable.js`, making it easier for developers to reproduce and configure custom grab positions and rotations. The main changes group around enhanced debugging and developer tooling.

Debugging and developer tooling improvements:

* Added a `debug` boolean property to the `holdable` component schema, allowing developers to enable or disable debug logging for grab position and rotation.
* When `debug` mode is enabled and an object is grabbed with the right hand, the component now logs a copy-pasteable attribute string to the console that reproduces the current grab position and rotation. If the left hand is used, a message is shown instructing the developer to use the right hand for accurate values.
* Introduced a new `generateDebugGrabAttributes` method, which calculates the correct position and rotation (in degrees) for the attribute, applies a bottom-corner offset for more accurate placement, and outputs a formatted string for easy reuse in the scene configuration.