### PR TITLE
Add touch event listeners for mobile movement tracking in speed modifier component

### DIFF
--- a/src/components/movement-speed-modifier/movement-speed-modifier.js
+++ b/src/components/movement-speed-modifier/movement-speed-modifier.js
@@ -32,6 +32,7 @@ const movementSpeedModifierComponent = {
         this.currentAppliedMultiplier = 1; // Set to 1 initially as the boost needs to be triggered
         this.axisX = 0;
         this.axisY = 0;
+        this.touchCount = 0;
         this.timeSinceLastLinePattern = 0;
         // Bind handlers to this component instance, and store the references so listeners can be removed later
         this.onThumbstickDown = this.onThumbstickDown.bind(this);
@@ -39,10 +40,13 @@ const movementSpeedModifierComponent = {
         this.onKeyDown = this.onKeyDown.bind(this);
         this.onKeyUp = this.onKeyUp.bind(this);
         this.onWindowBlur = this.onWindowBlur.bind(this);
+        this.onTouchStart = this.onTouchStart.bind(this);
+        this.onTouchEnd = this.onTouchEnd.bind(this);
         // Set up input listeners
         this.leftControllerEl = this.data.leftController;
         this.addLeftControllerListeners();
         this.addKeyboardListeners();
+        this.addTouchListeners();
         // Create the speed line container and line elements
         this.lineContainer = null;
         this.lineElements = [];
@@ -97,6 +101,7 @@ const movementSpeedModifierComponent = {
     remove: function () {
         this.removeLeftControllerListeners();
         this.removeKeyboardListeners();
+        this.removeTouchListeners();
         this.resetSpeeds();
         this.removeSpeedLines();
     },
@@ -143,6 +148,28 @@ const movementSpeedModifierComponent = {
         window.removeEventListener("keydown", this.onKeyDown);
         window.removeEventListener("keyup", this.onKeyUp);
         window.removeEventListener("blur", this.onWindowBlur);
+    },
+
+    /**
+     * Add touch listeners
+     *
+     * Adds touch listeners to track the number of fingers on the screen for mobile movement.
+     */
+    addTouchListeners: function () {
+        window.addEventListener("touchstart", this.onTouchStart);
+        window.addEventListener("touchend", this.onTouchEnd);
+        window.addEventListener("touchcancel", this.onTouchEnd);
+    },
+
+    /**
+     * Remove touch listeners
+     *
+     * Removes the touch listeners used for mobile movement tracking.
+     */
+    removeTouchListeners: function () {
+        window.removeEventListener("touchstart", this.onTouchStart);
+        window.removeEventListener("touchend", this.onTouchEnd);
+        window.removeEventListener("touchcancel", this.onTouchEnd);
     },
 
     /**
@@ -234,6 +261,30 @@ const movementSpeedModifierComponent = {
     },
 
     /**
+     * Touch start handler
+     *
+     * Tracks the number of fingers on the screen to detect forward or backward movement on mobile.
+     *
+     * @param {TouchEvent} event The touch event.
+     */
+    onTouchStart: function (event) {
+        this.touchCount = event.touches.length;
+        this.syncSpeedLinesVisibility();
+    },
+
+    /**
+     * Touch end handler
+     *
+     * Tracks the number of fingers on the screen to detect when movement stops on mobile.
+     *
+     * @param {TouchEvent} event The touch event.
+     */
+    onTouchEnd: function (event) {
+        this.touchCount = event.touches.length;
+        this.syncSpeedLinesVisibility();
+    },
+
+    /**
      * Is joystick forward
      *
      * Returns true when the left joystick is pushed forward at all.
@@ -287,7 +338,8 @@ const movementSpeedModifierComponent = {
         const keyboardMovingForward = this.keyboardForwardActive;
         const joystickMovingForward = this.isJoystickForward();
         const armSwingMovingForward = armSwingMovement && armSwingMovement.moving && !armSwingMovement.reverseHeld;
-        return keyboardMovingForward || joystickMovingForward || armSwingMovingForward;
+        const touchMovingForward = this.touchCount === 1; // 1 finger = forward, 2 = backward
+        return keyboardMovingForward || joystickMovingForward || armSwingMovingForward || touchMovingForward;
     },
 
     /**


### PR DESCRIPTION
This pull request improves support for mobile touch input to the `movement-speed-modifier` component. The main changes include tracking touch events, updating movement logic to recognize touch-based movement, and ensuring that speed lines show up when moving forward on mobile.

**Mobile touch input support:**

* Added `touchCount` property and methods (`onTouchStart`, `onTouchEnd`) to track the number of fingers on the screen, and update movement state accordingly. [[1]](diffhunk://#diff-07db03ded1e5bceba41c855aafdb1df31be5daa687985df795423d0207ad7187R35-R49) [[2]](diffhunk://#diff-07db03ded1e5bceba41c855aafdb1df31be5daa687985df795423d0207ad7187R263-R286)
* Implemented `addTouchListeners` and `removeTouchListeners` methods to manage touch event listeners during component lifecycle. [[1]](diffhunk://#diff-07db03ded1e5bceba41c855aafdb1df31be5daa687985df795423d0207ad7187R153-R174) [[2]](diffhunk://#diff-07db03ded1e5bceba41c855aafdb1df31be5daa687985df795423d0207ad7187R104)

**Movement logic updates:**

* Modified the `isMovingForward` method to support forward movement when one finger is on the screen (two fingers moves the player backwards, so that would register as `false`), allowing for mobile-friendly movement controls.

Trello: https://trello.com/c/GmhnPkKL